### PR TITLE
Update _pkgdown.yml

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -6,7 +6,7 @@ navbar:
   type: default
   right:
   - icon: fa-github fa-lg
-    href: https://github.com/chrismainey/FunnelPlotR
+    href: https://github.com/nhs-r-community/NHSRdatasets
 
 
 authors:


### PR DESCRIPTION
Hi there! While checking the pkgdown-site for the NHSRdatasets-package I found a wrongly directed link: 

I fixed typo for hyperlink to github repo in favicon on pkg down site

thanks for providing real world data people using R for health service research.