### PR TITLE
replacing link

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 <a href='https://nhsrcommunity.com/'><img src='https://nhs-r-community.github.io/assets/logo/nhsr-logo.png' width="100"/></a> *This package is part of the NHS-R Community suite of [R packages](https://nhsrcommunity.com/packages.html).*
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/github/all-contributors/nhs-r-community/NHSRDatasets?color=ee8449&style=flat-square)](#contributors)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 <!-- badges: start -->

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 <a href='https://nhsrcommunity.com/'><img src='https://nhs-r-community.github.io/assets/logo/nhsr-logo.png' width="100"/></a> *This package is part of the NHS-R Community suite of [R packages](https://nhsrcommunity.com/packages.html).*
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/github/all-contributors/projectOwner/projectName?color=ee8449&style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 <!-- badges: start -->

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ packages](https://nhsrcommunity.com/packages.html).*
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 
 [![All
-Contributors](https://img.shields.io/github/all-contributors/projectOwner/projectName?color=ee8449&style=flat-square)](#contributors)
+Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 <!-- badges: start -->

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ packages](https://nhsrcommunity.com/packages.html).*
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 
 [![All
-Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat-square)](#contributors-)
+Contributors](https://img.shields.io/github/all-contributors/nhs-r-community/NHSRDatasets?color=ee8449&style=flat-square)](#contributors)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 <!-- badges: start -->


### PR DESCRIPTION
Closes #106.

Adding more context: In #104, only the hex logo was added to the `README.Rmd`. But when knitted `README.md`'s ALL-CONTRIBUTORS-BADGE section also changed, I think because the `Rmd` had been changed previously but the changes not carried through to the `md`. I think I've set this back to what it used to be.